### PR TITLE
add support for accessing tags from entities

### DIFF
--- a/dynatrace/configuration_v1/metag.py
+++ b/dynatrace/configuration_v1/metag.py
@@ -1,3 +1,8 @@
-class METag:
-    def __init__(self):
-        pass
+from dynatrace.dynatrace_object import DynatraceObject
+
+class METag(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: dict):
+        self.context: str = raw_element.get("context")
+        self.key: str = raw_element.get("key")
+        self.value: str = raw_element.get("value")
+        self.string_representation: str = raw_element.get("stringRepresentation")

--- a/dynatrace/environment_v2/entity.py
+++ b/dynatrace/environment_v2/entity.py
@@ -91,7 +91,7 @@ class Entity(DynatraceObject):
 
     @property
     def tags(self) -> List[METag]:
-        return []
+        return self._tags
 
     @property
     def properties(self) -> List[dict]:
@@ -101,7 +101,7 @@ class Entity(DynatraceObject):
         self._display_name = raw_element.get("displayName")
         self._entity_id = raw_element.get("entityId")
         self._properties = raw_element.get("properties", {})
-
+        self._tags: List[METag] = [METag(raw_element=tag) for tag in raw_element.get("tags", {})]
 
 class EntityShortRepresentation(DynatraceObject):
     def _create_from_raw_data(self, raw_element):


### PR DESCRIPTION
Used the activegatemodules as a primary reference.

This allows you to access the tags returned from an entity list call. 

```
hosts = dt.entities.list('type("HOST"),tag("Azure")', fields="+tags,+properties")
for host in hosts:
    for tag in host.tags:
        print(tag.string_representation)
        print(tag.key)
        print(tag.value)
        print(tag.context)

>>[Azure]clusterName:et-demo1-sfcluster
>>clusterName
>>et-demo1-sfcluster
>>AZURE
```

Right now the string representation escapes characters. Not sure if that's what we want.