### PR TITLE
changed property names to match with what api json uses

### DIFF
--- a/dynatrace/configuration_v1/maintenance_windows.py
+++ b/dynatrace/configuration_v1/maintenance_windows.py
@@ -29,7 +29,7 @@ class Recurrence(DynatraceObject):
 class Schedule(DynatraceObject):
     @staticmethod
     def create(recurrence_type: str, start: str, end: str, zone_id: str, recurrence: Optional[Recurrence] = None):
-        raw_element = {"recurrenceType": recurrence_type, "recurrence": recurrence, "start_time": start, "end_time": end, "zone_id": zone_id}
+        raw_element = {"recurrenceType": recurrence_type, "recurrence": recurrence, "start": start, "end": end, "zoneId": zone_id}
         return Schedule(raw_element=raw_element)
 
     @property


### PR DESCRIPTION
I was getting None types for the schedule start and end, and noticed the key names in the raw element we create didn't all match with what the api uses. 

"recurrenceType" was right, but the rest such as "start_time" are expected to just be "start."